### PR TITLE
Updating the Chapel Tmbundle for missing keywords resolving issue #6690

### DIFF
--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -23,13 +23,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
+			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|inout|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|out|pragma|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
 			<key>name</key>
 			<string>keyword.control.chapel</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(bool|real|int|uint|imag|complex|dmap|domain|string|range|tuple)\b</string>
+			<string>\b(bool|real|int|uint|imag|complex|dmap|domain|string|range|tuple|subdomain|sync|opaque)\b</string>
 			<key>name</key>
 			<string>storage.type.chapel</string>
 		</dict>


### PR DESCRIPTION
 Resolving Issue  **Improve tmbundle support** #6690  by adding missing keywords **(  inout, out , ref, subdomain , sync and opaque )**to chapel tmbundle code . kindly review it 